### PR TITLE
@statisticsnorway must be in the name when publishing as an npm packa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Functionality includes:
 * Listing connections between variables and datasets
 
 The project makes limited use of the [Component library for SSB](https://github.com/statisticsnorway/ssb-component-library)
-and is based upon [react-reference-app](https://github.com/statisticsnorway/fe-react-reference-app).
+and is based upon [react-reference-app](https://github.com/statisticsnorway/react-reference-app).
 
 ### Use as a library
 If you want to use this application as a library in your project, simply install it from yarn.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "variable-search",
+  "name": "@statisticsnorway/dapla-variable-search",
   "version": "0.2.0",
   "description": "Variable and dataset search through GSIM for Statistics Norway Dataplatform",
   "main": "lib/bundle.js",

--- a/src/__tests__/AppSettings.test.js
+++ b/src/__tests__/AppSettings.test.js
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 
 import { AppSettings } from '../components'
 import { ApiContext, LanguageContext } from '../utilities'
-import { API, TEST_CONFIGURATIONS } from '../configurations'
+import { TEST_CONFIGURATIONS } from '../configurations'
 import { SETTINGS, TEST_IDS } from '../enums'
 
 const { alternativeApi, language } = TEST_CONFIGURATIONS


### PR DESCRIPTION
…ge. Also added the dapla- prefix because 'variable-search' is too generic for something published on npm, even though it is under our organization.